### PR TITLE
Made it possible to order a reboot from settings page

### DIFF
--- a/romfs-files/ap/index.html
+++ b/romfs-files/ap/index.html
@@ -739,8 +739,8 @@ progress::-webkit-progress-value {background-color: #ed0 !important;}
 				<tr><td align=left>
 				<input type=button class="btn" name="identify" value="ID Device"
 				onclick="do_identify();" style="font-size: 14pt">&nbsp;
-			<input type=button type="button" class="btn" name="identify" value="Reset"
-				onclick="do_factory_reset();" style="font-size: 14pt">
+			<input type=button class="btn" name="identify" value="Reboot"
+				onclick="do_reset();" style="font-size: 14pt">
 			</td></tr>
 
 				</table></fieldset>
@@ -1211,7 +1211,7 @@ function do_reset()
 	}
 
 	ws.close();
-	alert("Resetting...");
+	alert("Rebooting...");
 }
 
 function file_change()


### PR DESCRIPTION
do_factory_reset() function does not exist in current code and the "Reset" button on the Settings page therefore has no effect. 
I have changed the html-page to call do_reset() instead. I also labeled it "Reboot" as I think it will be more clear to the user what is really happening then.