### PR TITLE
Align esp idf nov2018

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,6 @@ CFLAGS+= -I$(PROJECT_PATH)/components/libwebsockets/plugins \
 	 -I$(IDF_PATH)/components/esp32/include \
 	 -I$(IDF_PATH)/components/lwip/port/esp32/include \
 	 -I$(IDF_PATH)/components/lwip/lwip/src/include \
-	 -I$(IDF_PATH)/components/lwip/include/apps
+	 -I$(IDF_PATH)/components/lwip/include/apps \
+         -I$(IDF_PATH)/components/esp_event/include
 export IDF_PATH

--- a/components/bootloader/CMakeLists.txt
+++ b/components/bootloader/CMakeLists.txt
@@ -1,0 +1,7 @@
+# bootloader component logic is all in project_include.cmake,
+# and subproject/CMakeLists.txt.
+#
+# This file is only included so the build system finds the
+# component
+
+

--- a/components/bootloader/Kconfig.projbuild
+++ b/components/bootloader/Kconfig.projbuild
@@ -49,24 +49,180 @@ config BOOTLOADER_SPI_WP_PIN
 
         The default value (GPIO 7) is correct for WP pin on ESP32-D2WD integrated flash.
 
-config BOOTLOADER_VDDSDIO_BOOST
-    bool "Increase VDDSDIO LDO voltage to 1.9V"
-    default y
+choice BOOTLOADER_VDDSDIO_BOOST
+    bool "VDDSDIO LDO voltage"
+    default BOOTLOADER_VDDSDIO_BOOST_1_9V
     help
         If this option is enabled, and VDDSDIO LDO is set to 1.8V (using EFUSE
         or MTDI bootstrapping pin), bootloader will change LDO settings to
         output 1.9V instead. This helps prevent flash chip from browning out
         during flash programming operations.
-        For 3.3V flash, this option has no effect.
+
+        This option has no effect if VDDSDIO is set to 3.3V, or if the internal
+        VDDSDIO regulator is disabled via efuse.
+
+config BOOTLOADER_VDDSDIO_BOOST_1_8V
+    bool "1.8V"
+    depends on !ESPTOOLPY_FLASHFREQ_80M
+config BOOTLOADER_VDDSDIO_BOOST_1_9V
+    bool "1.9V"
+endchoice
+
+config BOOTLOADER_FACTORY_RESET
+    bool "GPIO triggers factory reset"
+    default N
+    help
+        Allows to reset the device to factory settings:
+        - clear one or more data partitions;
+        - boot from "factory" partition.
+        The factory reset will occur if there is a GPIO input pulled low while device starts up.
+        See settings below.
+
+config BOOTLOADER_NUM_PIN_FACTORY_RESET
+    int "Number of the GPIO input for factory reset"
+    depends on BOOTLOADER_FACTORY_RESET
+    range 0 39
+    default 4
+    help
+        The selected GPIO will be configured as an input with internal pull-up enabled.
+        To trigger a factory reset, this GPIO must be pulled low on reset.
+        Note that GPIO34-39 do not have an internal pullup and an external one must be provided.
+
+config BOOTLOADER_OTA_DATA_ERASE
+    bool "Clear OTA data on factory reset (select factory partition)"
+    depends on BOOTLOADER_FACTORY_RESET
+    help
+        The device will boot from "factory" partition (or OTA slot 0 if no factory partition is present) after a factory reset.
+
+config BOOTLOADER_DATA_FACTORY_RESET
+     string "Comma-separated names of partitions to clear on factory reset"
+     depends on BOOTLOADER_FACTORY_RESET
+     default "nvs"
+     help
+        Allows customers to select which data partitions will be erased while factory reset.
+        
+        Specify the names of partitions as a comma-delimited with optional spaces for readability. (Like this: "nvs, phy_init, ...")
+        Make sure that the name specified in the partition table and here are the same. 
+        Partitions of type "app" cannot be specified here.
+
+config BOOTLOADER_APP_TEST
+    bool "GPIO triggers boot from test app partition"
+    default N
+    help
+        Allows to run the test app from "TEST" partition.
+        A boot from "test" partition will occur if there is a GPIO input pulled low while device starts up.
+        See settings below.
+
+config BOOTLOADER_NUM_PIN_APP_TEST
+    int "Number of the GPIO input to boot TEST partition"
+    depends on BOOTLOADER_APP_TEST
+    range 0 39
+    default 18
+    help
+        The selected GPIO will be configured as an input with internal pull-up enabled.
+        To trigger a test app, this GPIO must be pulled low on reset.
+        After the GPIO input is deactivated and the device reboots, the old application will boot. 
+        (factory or OTA[x]).
+        Note that GPIO34-39 do not have an internal pullup and an external one must be provided.
+
+config BOOTLOADER_HOLD_TIME_GPIO
+    int "Hold time of GPIO for reset/test mode (seconds)"
+    depends on BOOTLOADER_FACTORY_RESET || BOOTLOADER_APP_TEST
+    default 5
+    help
+        The GPIO must be held low continuously for this period of time after reset 
+        before a factory reset or test partition boot (as applicable) is performed.
+
+config BOOTLOADER_WDT_ENABLE
+    bool "Use RTC watchdog in start code"
+    default y
+    help
+        Tracks the execution time of startup code.
+        If the execution time is exceeded, the RTC_WDT will restart system.
+        It is also useful to prevent a lock up in start code caused by an unstable power source.
+        NOTE: Tracks the execution time starts from the bootloader code - re-set timeout, while selecting the source for slow_clk - and ends calling app_main.
+        Re-set timeout is needed due to WDT uses a SLOW_CLK clock source. After changing a frequency slow_clk a time of WDT needs to re-set for new frequency.
+        slow_clk depends on ESP32_RTC_CLOCK_SOURCE (INTERNAL_RC or EXTERNAL_CRYSTAL).
+
+config BOOTLOADER_WDT_DISABLE_IN_USER_CODE
+    bool "Allows RTC watchdog disable in user code"
+    depends on BOOTLOADER_WDT_ENABLE
+    default n
+    help
+        If it is set, the client must itself reset or disable rtc_wdt in their code (app_main()).
+        Otherwise rtc_wdt will be disabled before calling app_main function.
+        Use function rtc_wdt_feed() for resetting counter of rtc_wdt.
+        Use function rtc_wdt_disable() for disabling rtc_wdt.
+
+config BOOTLOADER_WDT_TIME_MS
+    int "Timeout for RTC watchdog (ms)"
+    depends on BOOTLOADER_WDT_ENABLE
+    default 9000
+    range 0 120000
+    help
+        Verify that this parameter is correct and more then the execution time. 
+        Pay attention to options such as reset to factory, trigger test partition and encryption on boot
+        - these options can increase the execution time. 
+        Note: RTC_WDT will reset while encryption operations will be performed.
 
 endmenu  # Bootloader
 
 
 menu "Security features"
 
+# These three are the actual options to check in code,
+# selected by the displayed options
+config SECURE_SIGNED_ON_BOOT
+    bool
+    default y
+    depends on SECURE_BOOT_ENABLED || SECURE_SIGNED_ON_BOOT_NO_SECURE_BOOT
+
+config SECURE_SIGNED_ON_UPDATE
+    bool
+    default y
+    depends on SECURE_BOOT_ENABLED || SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT
+
+config SECURE_SIGNED_APPS
+   bool
+   default y
+   depends on SECURE_SIGNED_ON_BOOT || SECURE_SIGNED_ON_UPDATE
+
+
+config SECURE_SIGNED_APPS_NO_SECURE_BOOT
+    bool "Require signed app images"
+    default n
+    depends on !SECURE_BOOT_ENABLED
+    help
+        Require apps to be signed to verify their integrity.
+
+        This option uses the same app signature scheme as hardware secure boot, but unlike hardware secure boot it does not prevent the bootloader from being physically updated. This means that the device can be secured against remote network access, but not physical access. Compared to using hardware Secure Boot this option is much simpler to implement.
+
+config SECURE_SIGNED_ON_BOOT_NO_SECURE_BOOT
+    bool "Bootloader verifies app signatures"
+    default n
+    depends on SECURE_SIGNED_APPS_NO_SECURE_BOOT
+    help
+        If this option is set, the bootloader will be compiled with code to verify that an app is signed before booting it.
+
+        If hardware secure boot is enabled, this option is always enabled and cannot be disabled.
+        If hardware secure boot is not enabled, this option doesn't add significant security by itself so most users will want to leave it disabled.
+
+config SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT
+    bool "Verify app signature on update"
+    default y
+    depends on SECURE_SIGNED_APPS_NO_SECURE_BOOT
+    help
+         If this option is set, any OTA updated apps will have the signature verified before being considered valid.
+
+         When enabled, the signature is automatically checked whenever the esp_ota_ops.h APIs are used for OTA updates,
+         or esp_image_format.h APIs are used to verify apps.
+
+         If hardware secure boot is enabled, this option is always enabled and cannot be disabled.
+         If hardware secure boot is not enabled, this option still adds significant security against network-based attackers by preventing spoofing of OTA updates.
+
 config SECURE_BOOT_ENABLED
-    bool "Enable secure boot in bootloader (READ DOCS FIRST)"
-    default N
+    bool "Enable hardware secure boot in bootloader (READ DOCS FIRST)"
+    default n
     help
         Build a bootloader which enables secure boot on first boot.
 
@@ -74,7 +230,7 @@ config SECURE_BOOT_ENABLED
 
         When enabling secure boot, JTAG and ROM BASIC Interpreter are permanently disabled by default.
 
-        Refer to https://esp-idf.readthedocs.io/en/latest/security/secure-boot.html before enabling.
+        Refer to https://docs.espressif.com/projects/esp-idf/en/latest/security/secure-boot.html before enabling.
 
 choice SECURE_BOOTLOADER_MODE
     bool "Secure bootloader mode"
@@ -101,12 +257,12 @@ endchoice
 
 config SECURE_BOOT_BUILD_SIGNED_BINARIES
      bool "Sign binaries during build"
-     depends on SECURE_BOOT_ENABLED
+     depends on SECURE_SIGNED_APPS
      default y
      help
-        Once secure boot is enabled, bootloader will only boot if partition table and app image are signed.
+        Once secure boot or signed app requirement is enabled, app images are required to be signed.
 
-        If enabled, these binary files are signed as part of the build process. The file named in "Secure boot private signing key" will be used to sign the image.
+        If enabled (default), these binary files are signed as part of the build process. The file named in "Secure boot private signing key" will be used to sign the image.
 
         If disabled, unsigned app/partition data will be built. They must be signed manually using espsecure.py (for example, on a remote signing server.)
 
@@ -115,7 +271,7 @@ config SECURE_BOOT_SIGNING_KEY
      depends on SECURE_BOOT_BUILD_SIGNED_BINARIES
      default secure_boot_signing_key.pem
      help
-        Path to the key file used to sign partition tables and app images for secure boot. Once secure boot is enabled, bootloader will only boot if partition table and app image are signed.
+        Path to the key file used to sign app images.
 
         Key file is an ECDSA private key (NIST256p curve) in PEM format.
 
@@ -128,17 +284,38 @@ config SECURE_BOOT_SIGNING_KEY
 
 config SECURE_BOOT_VERIFICATION_KEY
     string "Secure boot public signature verification key"
-    depends on SECURE_BOOT_ENABLED && !SECURE_BOOT_BUILD_SIGNED_BINARIES
+    depends on SECURE_SIGNED_APPS && !SECURE_BOOT_BUILD_SIGNED_BINARIES
     default signature_verification_key.bin
     help
-       Path to a public key file used to verify signed images. This key is compiled into the bootloader,
-       and may also be used to verify signatures on OTA images after download.
+       Path to a public key file used to verify signed images. This key is compiled into the bootloader and/or app,
+       to verify app images.
 
        Key file is in raw binary format, and can be extracted from a
        PEM formatted private key using the espsecure.py
        extract_public_key command.
 
-       Refer to https://esp-idf.readthedocs.io/en/latest/security/secure-boot.html before enabling.
+       Refer to https://docs.espressif.com/projects/esp-idf/en/latest/security/secure-boot.html before enabling.
+
+choice SECURE_BOOTLOADER_KEY_ENCODING
+    bool "Hardware Key Encoding"
+    depends on SECURE_BOOTLOADER_REFLASHABLE
+    default SECURE_BOOTLOADER_NO_ENCODING
+    help
+
+    In reflashable secure bootloader mode, a hardware key is derived from the signing key (with SHA-256) and can be written to efuse
+    with espefuse.py.
+
+    Normally this is a 256-bit key, but if 3/4 Coding Scheme is used on the device then the efuse key is truncated to 192 bits.
+
+    This configuration item doesn't change any firmware code, it only changes the size of key binary which is generated at build time.
+
+config SECURE_BOOTLOADER_KEY_ENCODING_256BIT
+       bool "No encoding (256 bit key)"
+
+config SECURE_BOOTLOADER_KEY_ENCODING_192BIT
+       bool "3/4 encoding (192 bit key)"
+
+endchoice
 
 config SECURE_BOOT_INSECURE
     bool "Allow potentially insecure options"
@@ -149,7 +326,7 @@ config SECURE_BOOT_INSECURE
 
        Only enable these options if you are very sure.
 
-       Refer to https://esp-idf.readthedocs.io/en/latest/security/secure-boot.html before enabling.
+       Refer to https://docs.espressif.com/projects/esp-idf/en/latest/security/secure-boot.html before enabling.
 
 config FLASH_ENCRYPTION_ENABLED
     bool "Enable flash encryption on boot (READ DOCS FIRST)"
@@ -160,7 +337,7 @@ config FLASH_ENCRYPTION_ENABLED
        Note: After first boot, the system will be permanently encrypted. Re-flashing an encrypted
        system is complicated and not always possible.
 
-       Read https://esp-idf.readthedocs.io/en/latest/security/flash-encryption.html before enabling.
+       Read https://docs.espressif.com/projects/esp-idf/en/latest/security/flash-encryption.html before enabling.
 
 config FLASH_ENCRYPTION_INSECURE
     bool "Allow potentially insecure options"
@@ -207,6 +384,13 @@ config SECURE_BOOT_ALLOW_JTAG
 
           Only set this option in testing environments.
 
+config SECURE_BOOT_ALLOW_SHORT_APP_PARTITION
+       bool "Allow app partition length not 64KB aligned"
+       depends on SECURE_BOOT_INSECURE
+       help
+           If not set (default), app partition size must be a multiple of 64KB. App images are padded to 64KB length, and the bootloader checks any trailing bytes after the signature (before the next 64KB boundary) have not been written. This is because flash cache maps entire 64KB pages into the address space. This prevents an attacker from appending unverified data after the app image in the flash, causing it to be mapped into the address space.
+
+           Setting this option allows the app partition length to be unaligned, and disables padding of the app image to this length. It is generally not recommended to set this option, unless you have a legacy partitioning scheme which doesn't support 64KB aligned partition lengths.
 
 config FLASH_ENCRYPTION_UART_BOOTLOADER_ALLOW_ENCRYPT
     bool "Leave UART bootloader encryption enabled"

--- a/components/bootloader/Makefile.projbuild
+++ b/components/bootloader/Makefile.projbuild
@@ -32,7 +32,8 @@ BOOTLOADER_MAKE= +\
 	V=$(V) \
 	BUILD_DIR_BASE=$(BOOTLOADER_BUILD_DIR) \
 	TEST_COMPONENTS= \
-	TESTS_ALL=
+	TESTS_ALL= \
+	EXCLUDE_COMPONENTS=
 
 .PHONY: bootloader-clean bootloader-flash bootloader-list-components bootloader $(BOOTLOADER_BIN)
 
@@ -48,14 +49,14 @@ ifndef CONFIG_SECURE_BOOT_ENABLED
 # If secure boot disabled, bootloader flashing is integrated
 # with 'make flash' and no warnings are printed.
 
-bootloader: $(BOOTLOADER_BIN)
+bootloader: $(BOOTLOADER_BIN) | check_python_dependencies
 	@echo $(SEPARATOR)
 	@echo "Bootloader built. Default flash command is:"
 	@echo "$(ESPTOOLPY_WRITE_FLASH) $(BOOTLOADER_OFFSET) $^"
 
 ESPTOOL_ALL_FLASH_ARGS += $(BOOTLOADER_OFFSET) $(BOOTLOADER_BIN)
 
-bootloader-flash: $(BOOTLOADER_BIN) $(call prereq_if_explicit,erase_flash)
+bootloader-flash: $(BOOTLOADER_BIN) $(call prereq_if_explicit,erase_flash) | check_python_dependencies
 	$(ESPTOOLPY_WRITE_FLASH) 0x1000 $^
 
 else ifdef CONFIG_SECURE_BOOTLOADER_ONE_TIME_FLASH
@@ -66,7 +67,7 @@ else ifdef CONFIG_SECURE_BOOTLOADER_ONE_TIME_FLASH
 # The flashing command is deliberately printed without an auto-reset
 # step, so the device doesn't immediately reset to flash itself.
 
-bootloader: $(BOOTLOADER_BIN)
+bootloader: $(BOOTLOADER_BIN) | check_python_dependencies
 	@echo $(SEPARATOR)
 	@echo "Bootloader built. One-time flash command is:"
 	@echo "$(subst hard_reset,no_reset,$(ESPTOOLPY_WRITE_FLASH)) $(BOOTLOADER_OFFSET) $(BOOTLOADER_BIN)"
@@ -77,12 +78,18 @@ else ifdef CONFIG_SECURE_BOOTLOADER_REFLASHABLE
 # Reflashable secure bootloader
 # generates a digest binary (bootloader + digest)
 
+ifdef CONFIG_SECURE_BOOTLOADER_KEY_ENCODING_192BIT
+KEY_DIGEST_LEN=192
+else
+KEY_DIGEST_LEN=256
+endif
+
 BOOTLOADER_DIGEST_BIN := $(BOOTLOADER_BUILD_DIR)/bootloader-reflash-digest.bin
-SECURE_BOOTLOADER_KEY := $(BOOTLOADER_BUILD_DIR)/secure-bootloader-key.bin
+SECURE_BOOTLOADER_KEY := $(BOOTLOADER_BUILD_DIR)/secure-bootloader-key-$(KEY_DIGEST_LEN).bin
 
 ifdef CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES
-$(SECURE_BOOTLOADER_KEY): $(SECURE_BOOT_SIGNING_KEY)
-	$(ESPSECUREPY) digest_private_key -k $< $@
+$(SECURE_BOOTLOADER_KEY): $(SECURE_BOOT_SIGNING_KEY) | check_python_dependencies
+	$(ESPSECUREPY) digest_private_key --keylen $(KEY_DIGEST_LEN) -k $< $@
 else
 $(SECURE_BOOTLOADER_KEY):
 	@echo "No pre-generated key for a reflashable secure bootloader is available, due to signing configuration."
@@ -104,9 +111,9 @@ bootloader: $(BOOTLOADER_DIGEST_BIN)
 	@echo "* After first boot, only re-flashes of this kind (with same key) will be accepted."
 	@echo "* Not recommended to re-use the same secure boot keyfile on multiple production devices."
 
-$(BOOTLOADER_DIGEST_BIN): $(BOOTLOADER_BIN) $(SECURE_BOOTLOADER_KEY)
+$(BOOTLOADER_DIGEST_BIN): $(BOOTLOADER_BIN) $(SECURE_BOOTLOADER_KEY) | check_python_dependencies
 	@echo "DIGEST $(notdir $@)"
-	$(Q) $(ESPSECUREPY) digest_secure_bootloader -k $(SECURE_BOOTLOADER_KEY) -o $@ $<
+	$(ESPSECUREPY) digest_secure_bootloader -k $(SECURE_BOOTLOADER_KEY) -o $@ $<
 
 else # CONFIG_SECURE_BOOT_ENABLED && !CONFIG_SECURE_BOOTLOADER_REFLASHABLE && !CONFIG_SECURE_BOOTLOADER_ONE_TIME_FLASH
 bootloader:
@@ -115,10 +122,12 @@ bootloader:
 endif
 
 ifndef CONFIG_SECURE_BOOT_ENABLED
-# don't build bootloader by default is secure boot is enabled
+# don't build bootloader by default if secure boot is enabled
 all_binaries: $(BOOTLOADER_BIN)
 endif
 
 bootloader-clean: $(SDKCONFIG_MAKEFILE)
 	$(BOOTLOADER_MAKE) app-clean
+ifdef CONFIG_SECURE_BOOTLOADER_REFLASHABLE
 	rm -f $(SECURE_BOOTLOADER_KEY) $(BOOTLOADER_DIGEST_BIN)
+endif

--- a/components/bootloader/project_include.cmake
+++ b/components/bootloader/project_include.cmake
@@ -1,0 +1,34 @@
+if(BOOTLOADER_BUILD)
+    return()  # don't keep recursing!
+endif()
+
+# Glue to build the bootloader subproject binary as an external
+# cmake project under this one
+#
+#
+set(bootloader_build_dir "${CMAKE_BINARY_DIR}/bootloader")
+set(bootloader_binary_files
+    "${bootloader_build_dir}/bootloader.elf"
+    "${bootloader_build_dir}/bootloader.bin"
+    "${bootloader_build_dir}/bootloader.map"
+    )
+
+externalproject_add(bootloader
+    # TODO: support overriding the bootloader in COMPONENT_PATHS
+    SOURCE_DIR "${IDF_PATH}/components/bootloader/subproject"
+    BINARY_DIR "${bootloader_build_dir}"
+    CMAKE_ARGS  -DSDKCONFIG=${SDKCONFIG} -DIDF_PATH=${IDF_PATH} -DEXTRA_COMPONENT_DIRS=${COMPONENT_DIRS}
+                -DTESTS_ALL=0 -DTEST_COMPONENTS=""
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS 1  # no easy way around this...
+    BUILD_BYPRODUCTS ${bootloader_binary_files}
+    )
+
+# this is a hack due to an (annoying) shortcoming in cmake, it can't
+# extend the 'clean' target to the external project
+# see thread: https://cmake.org/pipermail/cmake/2016-December/064660.html
+#
+# So for now we just have the top-level build remove the final build products...
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY
+    ADDITIONAL_MAKE_CLEAN_FILES
+    ${bootloader_binary_files})

--- a/components/bootloader/subproject/CMakeLists.txt
+++ b/components/bootloader/subproject/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.5)
+
+if(NOT SDKCONFIG)
+    message(FATAL_ERROR "Bootloader subproject expects the SDKCONFIG variable to be passed "
+        "in by the parent build process.")
+endif()
+
+if(NOT IDF_PATH)
+    message(FATAL_ERROR "Bootloader subproject expects the IDF_PATH variable to be passed "
+        "in by the parent build process.")
+endif()
+
+set(COMPONENTS bootloader esptool_py esp32 partition_table soc bootloader_support log spi_flash micro-ecc soc main)
+set(BOOTLOADER_BUILD 1)
+add_definitions(-DBOOTLOADER_BUILD=1)
+
+set(COMPONENT_REQUIRES_COMMON log esp32 soc)
+
+include("${IDF_PATH}/tools/cmake/project.cmake")
+project(bootloader)
+
+target_linker_script(bootloader.elf
+    "main/esp32.bootloader.ld"
+    "main/esp32.bootloader.rom.ld")
+# Imported from esp32 component
+target_linker_script(bootloader.elf ${ESP32_BOOTLOADER_LINKER_SCRIPTS})
+
+target_link_libraries(bootloader.elf gcc)

--- a/components/bootloader/subproject/main/CMakeLists.txt
+++ b/components/bootloader/subproject/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(COMPONENT_SRCS "bootloader_start.c")
+set(COMPONENT_ADD_INCLUDEDIRS "")
+set(COMPONENT_REQUIRES "bootloader bootloader_support")
+register_component()

--- a/components/bootloader/subproject/main/bootloader_start.c
+++ b/components/bootloader/subproject/main/bootloader_start.c
@@ -58,18 +58,18 @@ static int selected_boot_partition(const bootloader_state_t *bs);
  * The hardware is mostly uninitialized, flash cache is down and the app CPU is in reset.
  * We do have a stack, so we can do the initialization in C.
  */
-void call_start_cpu0()
+void __attribute__((noreturn)) call_start_cpu0()
 {
     // 1. Hardware initialization
     if (bootloader_init() != ESP_OK) {
-        return;
+        bootloader_reset();
     }
 
     // 2. Select the number of boot partition
     bootloader_state_t bs = { 0 };
     int boot_index = select_partition_number(&bs);
     if (boot_index == INVALID_INDEX) {
-        return;
+        bootloader_reset();
     }
 
     /* we can leave a magic at end of fast RTC ram to force next boot into FACTORY */

--- a/components/bootloader/subproject/main/esp32.bootloader.ld
+++ b/components/bootloader/subproject/main/esp32.bootloader.ld
@@ -15,7 +15,12 @@ MEMORY
   dport0_seg (RW) :                 	org = 0x3FF00000, len = 0x10
   /* IRAM POOL1, used for APP CPU cache. Bootloader runs from here during the final stage of loading the app because APP CPU is still held in reset, the main app enables APP CPU cache */
   iram_loader_seg (RWX) :           org = 0x40078000, len = 0x8000  /* 32KB, APP CPU cache */
-  iram_seg (RWX) :                  org = 0x40080000, len = 0x10000 /* 64KB, IRAM */
+  /* 63kB, IRAM. We skip the first 1k to prevent the entry point being
+     placed into the same range as exception vectors in the app.
+     This leads to idf_monitor decoding ROM bootloader "entry 0x40080xxx"
+     message as one of the exception vectors, which looks scary to users.
+  */
+  iram_seg (RWX) :                  org = 0x40080400, len = 0xfc00
   /* 64k at the end of DRAM, after ROM bootloader stack */
   dram_seg (RW) :                  	org = 0x3FFF0000, len = 0x10000
 }
@@ -30,25 +35,31 @@ SECTIONS
   .iram_loader.text :
   {
     . = ALIGN (16);
-    _stext = .;
-    _text_start = ABSOLUTE(.);
+    _loader_text_start = ABSOLUTE(.);
     *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
      *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
     *liblog.a:(.literal .text .literal.* .text.*)
     *libgcc.a:(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_utility.o(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:esp_image_format.o(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_random.o(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_flash.o(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:flash_partitions.o(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_sha.o(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:bootloader_common.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:bootloader_random.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:efuse.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:esp_image_format.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:flash_partitions.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:secure_boot.*(.literal .text .literal.* .text.*)
+    *libbootloader_support.a:secure_boot_signatures.*(.literal .text .literal.* .text.*)
+    *libmicro-ecc.a:*.*(.literal .text .literal.* .text.*)
+    *libspi_flash.a:*.*(.literal .text .literal.* .text.*)
+    *libsoc.a:rtc_wdt.*(.literal .text .literal.* .text.*)
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)
-    _text_end = ABSOLUTE(.);
-    _etext = .;
+    _loader_text_end = ABSOLUTE(.);
   } > iram_loader_seg
-  
+
   .iram.text :
   {
     . = ALIGN (16);
@@ -113,13 +124,13 @@ SECTIONS
     . = (. + 3) & ~ 3;
     /*  C++ constructor and destructor tables, properly ordered:  */
     __init_array_start = ABSOLUTE(.);
-    KEEP (*crtbegin.o(.ctors))
-    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*crtbegin.*(.ctors))
+    KEEP (*(EXCLUDE_FILE (*crtend.*) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
     __init_array_end = ABSOLUTE(.);
-    KEEP (*crtbegin.o(.dtors))
-    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*crtbegin.*(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.*) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
     /*  C++ exception handlers table:  */

--- a/components/bootloader/subproject/main/esp32.bootloader.rom.ld
+++ b/components/bootloader/subproject/main/esp32.bootloader.rom.ld
@@ -1,1 +1,4 @@
 PROVIDE ( ets_update_cpu_frequency = 0x40008550 ); /* Updates g_ticks_per_us on the current CPU only; not on the other core */
+PROVIDE ( MD5Final = 0x4005db1c );
+PROVIDE ( MD5Init = 0x4005da7c );
+PROVIDE ( MD5Update = 0x4005da9c );


### PR DESCRIPTION
esp-idf master has updated the bootloader code quite a bit, and lws-esp32-factory does not compile anymore without changes. They have also broken out esp_event.h to a separate folder as one of the steps when they have been adding an event loop library. I have just rebased the lws bootloader code to the new esp bootloader code and added the esp_event lib to the Makefile.

Also, mbedtls has been updated to 2.13.1 so your mbedtls patch should be updated again I guess, but that is not included in this pull req. I made a quick try [myself](https://github.com/FredrikFornstad/mbedtls/commits/mbedtls-2.13.1-idf-dynbuf) but I am not sure if it is correct or not... 
I guess the esp_event path also needs to be added to the lws-esp32-test-server-demos app too.